### PR TITLE
feature-9/encoder logic

### DIFF
--- a/lib/taptag.rb
+++ b/lib/taptag.rb
@@ -4,6 +4,7 @@ require 'taptag/pn532/structs'
 require 'taptag/pn532/library_constants'
 require 'taptag/pn532/pn532'
 require 'taptag/nfc'
+require 'taptag/encoder'
 
 # Ruby gem for controlling the Waveshare PN532 NFC HAT
 module Taptag

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -7,9 +7,30 @@ module Taptag
         str.chars.map(&:ord)
       end
 
+      # Takes the +str+ and splits it into +blks+ frames
+      def slice_string(str, blks)
+        bloks = case blks
+                when :mifare
+                  16
+                when :ntag
+                  4
+                when ->(b) { b.is_a?(Integer) }
+                  blks
+                end
+
+        frames = str.each_slice(bloks).to_a
+        frames.last << 0 until frames.last.length == bloks
+
+        frames
+      end
+
       # Returns just the write safe blocks for mifare
-      def writable_mifare_blocks
+      def writable_mifare_blocks(blocks = nil)
         @writable_mifare_blocks ||= (1..63).to_a - (0..15).map { |x| (4 * x) + 3 }
+
+        return @writable_mifare_blocks unless blocks
+
+        blocks.map.with_index { |i, x| [@writable_mifare_blocks[x], i] }
       end
     end
   end

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -7,6 +7,11 @@ module Taptag
         str.chars.map(&:ord)
       end
 
+      # Takes +bytes+ and converts it back into a string
+      def decode_string(bytes)
+        bytes.map(&:chr).join
+      end
+
       # Takes the +str+ and splits it into +blks+ frames
       def slice_string(str, blks)
         bloks = case blks

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -2,6 +2,16 @@ module Taptag
   # Handles translating messages to byte frames for writing to devices
   class Encoder
     class << self
+      def call(input, fmt = :mifare, blk_filter = writable_mifare_blocks)
+        if input.is_a?(String)
+          zip_blocks(slice_string(encode_string(input), fmt))
+        elsif identify_2d_array(input)
+          reduce_blocks(input, blk_filter)
+        elsif input.is_a?(Array)
+          slice_string(input, fmt)
+        end
+      end
+
       # Takes +str+ and converts the chars to ordinals
       def encode_string(str)
         str.chars.map(&:ord)
@@ -9,10 +19,12 @@ module Taptag
 
       # Takes +bytes+ and converts it back into a string
       def decode_string(bytes)
-        bytes.map(&:chr).join
+        bytes.map(&:chr)
+             .reject(&:zero?)
+             .join
       end
 
-      # Takes the +str+ and splits it into +blks+ frames
+      # Takes the +str+ and splits it into +blks+ frames with some shorthand
       def slice_string(str, blks)
         bloks = case blks
                 when :mifare
@@ -29,13 +41,33 @@ module Taptag
         frames
       end
 
+      # Takes in +blks+ and a +filter+ array to select blocks
+      def reduce_blocks(blks, filter = writable_mifare_blocks)
+        if identify_2d_array(blks)
+          hsh = blks.to_h
+          filter.map { |x| hsh[x] }.compact.flatten
+        else
+          filter.map { |x| blks[x] }.compact.flatten
+        end
+      end
+
+      def zip_blocks(blks, filter = writable_mifare_blocks)
+        filter.map
+              .with_index { |i, x| [i, blks[x]] }
+              .reject { |_a, b| b.nil? }
+      end
+
       # Returns just the write safe blocks for mifare
-      def writable_mifare_blocks(blocks = nil)
+      def writable_mifare_blocks
         @writable_mifare_blocks ||= (1..63).to_a - (0..15).map { |x| (4 * x) + 3 }
+      end
 
-        return @writable_mifare_blocks unless blocks
+      private
 
-        blocks.map.with_index { |i, x| [@writable_mifare_blocks[x], i] }
+      def identify_2d_array(arry)
+        arry.all? { |x| x.is_a?(Array) } &&
+          arry.all? { |x| x.length == 2 } &&
+          arry.all? { |x| x[0].is_a?(Integer) }
       end
     end
   end

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -15,6 +15,8 @@ module Taptag
         end
       end
 
+      alias [] call
+
       # Takes +str+ and converts the chars to ordinals
       def encode_string(str)
         str.chars.map(&:ord)

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -6,7 +6,7 @@ module Taptag
         if input.is_a?(String)
           zip_blocks(slice_string(encode_string(input), fmt))
         elsif identify_2d_array(input)
-          reduce_blocks(input, blk_filter)
+          decode_string reduce_blocks(input, blk_filter)
         elsif input.is_a?(Array)
           slice_string(input, fmt)
         end
@@ -19,8 +19,8 @@ module Taptag
 
       # Takes +bytes+ and converts it back into a string
       def decode_string(bytes)
-        bytes.map(&:chr)
-             .reject(&:zero?)
+        bytes.reject(&:zero?)
+             .map(&:chr)
              .join
       end
 

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -1,0 +1,16 @@
+module Taptag
+  # Handles translating messages to byte frames for writing to devices
+  class Encoder
+    class << self
+      # Takes +str+ and converts the chars to ordinals
+      def encode_string(str)
+        str.chars.map(&:ord)
+      end
+
+      # Returns just the write safe blocks for mifare
+      def writable_mifare_blocks
+        @writable_mifare_blocks ||= (1..63).to_a - (0..15).map { |x| (4 * x) + 3 }
+      end
+    end
+  end
+end

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -65,6 +65,7 @@ module Taptag
 
       private
 
+      # Takes in an +arg+, allowing for symbols to stand in
       def blk_length(arg)
         case arg
         when :mifare
@@ -76,6 +77,7 @@ module Taptag
         end
       end
 
+      # Takes in an +arry+ and determines whether it is a [1, n] length array
       def identify_2d_array(arry)
         arry.all? { |x| x.is_a?(Array) } &&
           arry.all? { |x| x.length == 2 } &&

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -26,14 +26,7 @@ module Taptag
 
       # Takes the +str+ and splits it into +blks+ frames with some shorthand
       def slice_string(str, blks)
-        bloks = case blks
-                when :mifare
-                  16
-                when :ntag
-                  4
-                when ->(b) { b.is_a?(Integer) }
-                  blks
-                end
+        bloks = blk_length(blks)
 
         frames = str.each_slice(bloks).to_a
         frames.last << 0 until frames.last.length == bloks
@@ -51,10 +44,18 @@ module Taptag
         end
       end
 
+      # Takes in the +blks+ and uses the +filter to label the frames
       def zip_blocks(blks, filter = writable_mifare_blocks)
         filter.map
               .with_index { |i, x| [i, blks[x]] }
               .reject { |_a, b| b.nil? }
+      end
+
+      # Takes in the +filter+ and zips it with blank blocks
+      def blank_blocks(filter = writable_mifare_blocks, blks = Array.new(16, 0))
+        filter.map do |x|
+          [x, blks]
+        end
       end
 
       # Returns just the write safe blocks for mifare
@@ -63,6 +64,17 @@ module Taptag
       end
 
       private
+
+      def blk_length(arg)
+        case arg
+        when :mifare
+          16
+        when :ntag
+          4
+        when ->(b) { b.is_a?(Integer) }
+          arg
+        end
+      end
 
       def identify_2d_array(arry)
         arry.all? { |x| x.is_a?(Array) } &&

--- a/lib/taptag/encoder.rb
+++ b/lib/taptag/encoder.rb
@@ -2,6 +2,9 @@ module Taptag
   # Handles translating messages to byte frames for writing to devices
   class Encoder
     class << self
+      # Master input function, takes in +input+ and optional values for +fmt+ and +blk_filter+
+      # and can turn strings into 2d write arrays, 2d arrays into strings,
+      # and 1D arrays into 2d arrays
       def call(input, fmt = :mifare, blk_filter = writable_mifare_blocks)
         if input.is_a?(String)
           zip_blocks(slice_string(encode_string(input), fmt))

--- a/lib/taptag/nfc.rb
+++ b/lib/taptag/nfc.rb
@@ -26,6 +26,16 @@ module Taptag
         buffer[0...resp]
       end
 
+      # Detect card format through uid length
+      def card_format(cuid = card_uid)
+        case cuid.length
+        when PN532::MIFARE_UID_SINGLE_LENGTH
+          :mifare
+        when PN532::MIFARE_UID_DOUBLE_LENGTH
+          :ntag
+        end
+      end
+
       ### Mifare methods ###
 
       # Authenticates rw access to a block

--- a/lib/taptag/nfc.rb
+++ b/lib/taptag/nfc.rb
@@ -96,7 +96,7 @@ module Taptag
       # Takes in a 2D array of +blocks+, of format [blk_num, data[]], a default +cuid+,
       # and the default +key+ to write multiple blocks on the card
       def write_mifare_card(blocks, cuid = card_uid, key = PN532::MIFARE_DEFAULT_KEY)
-        blocks.each { |blk, data| write_mifare_block(blk, data, cuid, key) }
+        blocks.each { |blk, data| write_mifare_block(data, blk, auth_mifare_block(blk, cuid, key)) }
       end
 
       ### NTag methods ###

--- a/lib/taptag/nfc.rb
+++ b/lib/taptag/nfc.rb
@@ -96,7 +96,7 @@ module Taptag
       # Takes in a 2D array of +blocks+, of format [blk_num, data[]], a default +cuid+,
       # and the default +key+ to write multiple blocks on the card
       def write_mifare_card(blocks, cuid = card_uid, key = PN532::MIFARE_DEFAULT_KEY)
-        blocks.each { |blk, data| write_mifare_block(data, blk, auth_mifare_block(blk, cuid, key)) }
+        blocks.each { |blk, data| write_mifare_block(blk, data, auth_mifare_block(blk, cuid, key)) }
       end
 
       ### NTag methods ###


### PR DESCRIPTION
- Add card format detection
- Adds base encoder class with block and ordenalizing methods
- Require the encoder
- Adds the slice_string method to break into blocks, and an optional argument to writable_mifare_blocks to create a 2D array
- Adds a decode_string method_
- Added logic for translating blocks back and forth, and a magic call method
- Fixed the decoder logic, and made the call function decode strings for 2d arrays
- Made the write block call within write card more extensible
- Switched argument order
- Adds the ability to set the array used to blank blocks en masse
- Add some docs
- Document Encoder.call
- Add an alias for call

Closes #9
