### PR TITLE
bug/ntag tryagain loop

### DIFF
--- a/lib/taptag/nfc.rb
+++ b/lib/taptag/nfc.rb
@@ -121,7 +121,8 @@ module Taptag
       rescue IOError => e
         raise e unless e.message =~ /ERROR_CONTEXT/
 
-        card_uid
+        raise e unless card_uid
+
         sleep 1
         read_ntag_block(blk)
       end


### PR DESCRIPTION
Added a bugfix for the ntag_read_block method looping infinitely if there is no card﻿
